### PR TITLE
Fix retrieving unicode fields from the server

### DIFF
--- a/mysql/utilities/common/server.py
+++ b/mysql/utilities/common/server.py
@@ -57,6 +57,8 @@ def tostr(value):
 
     Returns value as str instance or None.
     """
+    if isinstance(value, unicode):
+        value = value.encode('utf-8')
     return None if value is None else str(value)
 
 


### PR DESCRIPTION
I happened to have an accented character in a varchar field here that
made mysqldbexport choke with:
UnicodeEncodeError: 'ascii' codec can't encode character u'\xe8' in position 10: ordinal not in range(128)

So we check if the value is a unicode string, and if so we encode it
back to a UTF-8 string.

Works for me(TM) but I didn't run any other test.